### PR TITLE
Forhindret stretching på bilder

### DIFF
--- a/components/events/singleInfoCard.tsx
+++ b/components/events/singleInfoCard.tsx
@@ -33,7 +33,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
             className={`container mx-auto overflow-hidden rounded-xl bg-white pb-5 sm:w-[1000px] ${className}`}>
             {image && (
                 <div className={"relative aspect-[16/7] w-full"}>
-                    <SanityImage image={image} alt={image.alt} fill />
+                    <SanityImage image={image} alt={image.alt} fill className={"object-cover"} />
                 </div>
             )}
 

--- a/components/events/singleInfoCard.tsx
+++ b/components/events/singleInfoCard.tsx
@@ -32,7 +32,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
         className={`container mx-auto overflow-hidden rounded-xl bg-white pb-5 sm:w-[1000px] ${className}`}>
         {image && (
             <div className={"relative aspect-[16/7] w-full"}>
-                <SanityImage image={image} alt={image.alt} fill />
+                <SanityImage image={image} alt={image.alt} fill className={"object-cover"} />
             </div>
         )}
 

--- a/components/events/thumbnail.tsx
+++ b/components/events/thumbnail.tsx
@@ -21,7 +21,7 @@ const Thumbnail: Component<
         <SanityImage
             image={image}
             alt={image.alt}
-            className={`rounded-xl ${className}`}
+            className={`rounded-xl object-cover ${className}`}
             fill
             sizes={"33vw"}
         />


### PR DESCRIPTION
Lagt inn object-cover på bildene slik at de skal fylle container uten å stretche.

Dette virker ikke på alle bilder, og klarer ikke finne en løsning for det. Men det er bare bilder som er veldig brede og lange, eller motsatt som blir problematisk, som Root logoen. Ideelt sett bør bilder være mellom 16/9 og 1/1 

Også litt usikker på høyden på bildet, jeg føler det er litt høyt, men hvis det er mindre så kan store deler av bilde forsvinne utenfor boksen i værste fall