### PR TITLE
Erstattet Markdown med Block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ next-env.d.ts
 
 # IDE
 /.idea
+
+# lighthouse
+*.report.html
+

--- a/app/(root)/arrangement/[slug]/page.tsx
+++ b/app/(root)/arrangement/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation"
 import SingleInfoCard from "@/components/cards/singleInfoCard"
 import { type Metadata } from "next"
 import { createEvent } from "ics"
-import { getEventTypeLabel, markdownToText } from "@/sanity/lib/utils"
+import { getDescription, getEventTypeLabel } from "@/sanity/lib/utils"
 import type { RootEvent } from "@/sanity/types"
 import IcsButton from "@/components/buttons/icsButton"
 import { Date, Time } from "@/components/date"
@@ -85,7 +85,7 @@ export async function generateMetadata({ params }: PageProps<Params>): Promise<M
 
     return {
         title: `${event.title} | Root Linjeforening`,
-        description: await markdownToText(event.description),
+        description: await getDescription(event),
     }
 }
 
@@ -98,10 +98,11 @@ export async function generateMetadata({ params }: PageProps<Params>): Promise<M
  */
 async function createIcsEvent(event: RootEvent): Promise<string | undefined> {
     let icsEvent: string | undefined = undefined
+
     createEvent(
         {
             title: event.title,
-            description: await markdownToText(event.description),
+            description: await getDescription(event),
             location: event.address_text,
             start: toDateTuple(event.start_time),
             duration: { hours: 2 },

--- a/app/(root)/arrangement/[slug]/page.tsx
+++ b/app/(root)/arrangement/[slug]/page.tsx
@@ -35,6 +35,7 @@ const EventPage: AsyncPage<Params> = async ({ params }) => {
         <SingleInfoCard
             title={event.title}
             description={event.description}
+            descriptionBlock={event.description_block}
             image={event.hero_image}
             maxParticipants={
                 event.max_participants ? `Antall plasser er ${event.max_participants}` : undefined

--- a/app/(root)/globals.css
+++ b/app/(root)/globals.css
@@ -32,7 +32,7 @@
     }
 
     .header-gradient {
-        @apply from-root-primary via-root-primary to-root-secondary bg-gradient-to-r;
+        @apply bg-gradient-to-r from-root-primary via-root-primary to-root-secondary;
     }
 }
 
@@ -46,14 +46,19 @@
 
 button,
 a[role="button"] {
-    @apply focus:border-root-primary focus:border;
+    @apply focus:border focus:border-root-primary;
 }
 
+.link,
 a {
-    @apply text-root-primary hover:text-root-primary-dark;
+    @apply text-root-primary no-underline hover:text-root-primary-dark;
 }
 
-p {
+/*
+    Gjør at man kan bruke flere tomme p-tagger for å lage luft.
+    Nyttig sammen med PortableText
+*/
+p:empty + p:empty {
     @apply min-h-[1px];
 }
 
@@ -70,25 +75,25 @@ br {
 }
 
 h1 {
-    @apply text-dark-title text-4xl font-bold;
+    @apply text-4xl font-bold text-dark-title;
 }
 
 h2 {
-    @apply text-dark-title text-3xl font-bold;
+    @apply text-3xl font-bold text-dark-title;
 }
 
 h3 {
-    @apply text-dark-title text-2xl font-bold;
+    @apply text-2xl font-bold text-dark-title;
 }
 
 h4 {
-    @apply text-dark-title text-xl font-bold;
+    @apply text-xl font-bold text-dark-title;
 }
 
 h5 {
-    @apply text-dark-title text-lg font-bold;
+    @apply text-lg font-bold text-dark-title;
 }
 
 h6 {
-    @apply text-dark-title text-base font-bold;
+    @apply text-base font-bold text-dark-title;
 }

--- a/app/(root)/globals.css
+++ b/app/(root)/globals.css
@@ -53,6 +53,10 @@ a {
     @apply text-root-primary hover:text-root-primary-dark;
 }
 
+p {
+    @apply min-h-[1px];
+}
+
 ul {
     @apply list-disc pl-3.5;
 }

--- a/app/(root)/stilling/[slug]/page.tsx
+++ b/app/(root)/stilling/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation"
 import SingleInfoCard from "@/components/cards/singleInfoCard"
 import { type Metadata } from "next"
 import { Date } from "@/components/date"
-import { markdownToText } from "@/sanity/lib/utils"
+import { getDescription } from "@/sanity/lib/utils"
 
 interface Params {
     slug: string
@@ -26,6 +26,7 @@ const JobAdvertPage: AsyncPage<Params> = async ({ params }) => {
         <SingleInfoCard
             title={ad.title}
             description={ad.description}
+            descriptionBlock={ad.description_block}
             image={ad.image}
             maxParticipants={
                 ad.number_of_positions
@@ -70,6 +71,6 @@ export async function generateMetadata(props: PageProps<Params>): Promise<Metada
 
     return {
         title: `${ad.title} | Root Linjeforening`,
-        description: await markdownToText(ad.description),
+        description: await getDescription(ad),
     }
 }

--- a/components/cards/singleInfoCard.tsx
+++ b/components/cards/singleInfoCard.tsx
@@ -68,7 +68,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
             </div>
 
             {descriptionBlock ? (
-                <div className={"prose"}>
+                <div className={"prose my-5 max-w-none"}>
                     <PortableText value={descriptionBlock} components={components} />
                 </div>
             ) : (

--- a/components/cards/singleInfoCard.tsx
+++ b/components/cards/singleInfoCard.tsx
@@ -4,11 +4,14 @@ import { ExternalLinkButton } from "@/components/buttons/button"
 import Markdown from "@/components/markdown"
 import { ExternalLink } from "@/components/link"
 import type { MarkdownString, SanityImageObject } from "@/sanity/types"
+import { PortableText } from "@portabletext/react"
+import { type TypedObject } from "sanity"
 
 interface SingleInfoCardProps extends ChildProps {
     image?: SanityImageObject
     title?: string
     description?: MarkdownString
+    descriptionBlock?: TypedObject | TypedObject[]
     addressText?: string
     addressUrl?: string
     maxParticipants?: string
@@ -21,6 +24,7 @@ interface SingleInfoCardProps extends ChildProps {
  * @param image Bildet som vises på toppen av kortet. Bør være i 16:7 format. Hvis ikke vil bildet bli beskåret i høyden. Dersom bildet er for lavt kan det bli beskåret i bredden.
  * @param title Tittelen på kortet
  * @param description Beskrivelsen på kortet i Markdown format
+ * @param descriptionBlock Beskrivelsen på kortet i PortableText format
  * @param addressText Teksten som vises for adressen. Dersom denne ikke er satt vil ikke adressekomponenten vises.
  * @param addressUrl URLen til adressen. Dersom den er satt vil adressen bli en lenke.
  * @param maxParticipants Maks antall deltakere på arrangementet. Dersom denne ikke er satt vil ikke deltakerkomponenten vises.
@@ -33,6 +37,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
     image,
     title,
     description,
+    descriptionBlock,
     addressText,
     addressUrl,
     maxParticipants,
@@ -50,7 +55,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
         )}
 
         {title && (
-            <h1 className={"text-dark-title my-5 text-center text-2xl sm:text-4xl"}>{title}</h1>
+            <h1 className={"my-5 text-center text-2xl text-dark-title sm:text-4xl"}>{title}</h1>
         )}
         <div className={"px-5 sm:px-32"}>
             <div className={"flex-center flex-wrap gap-5"}>
@@ -61,6 +66,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
                 {children}
             </div>
 
+            {descriptionBlock && <PortableText value={descriptionBlock} />}
             <Markdown className={"my-5"} markdown={description} />
         </div>
         {buttonUrl && (

--- a/components/cards/singleInfoCard.tsx
+++ b/components/cards/singleInfoCard.tsx
@@ -6,6 +6,7 @@ import { ExternalLink } from "@/components/link"
 import type { MarkdownString, SanityImageObject } from "@/sanity/types"
 import { PortableText } from "@portabletext/react"
 import { type TypedObject } from "sanity"
+import { components } from "@/sanity/lib/portabletext"
 
 interface SingleInfoCardProps extends ChildProps {
     image?: SanityImageObject
@@ -37,6 +38,7 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
     image,
     title,
     description,
+    descriptionBlock,
     addressText,
     addressUrl,
     maxParticipants,
@@ -65,8 +67,13 @@ const SingleInfoCard: Component<SingleInfoCardProps> = ({
                 {children}
             </div>
 
-            {descriptionBlock && <PortableText value={descriptionBlock} />}
-            <Markdown className={"prose my-5 max-w-none"} markdown={description} />
+            {descriptionBlock ? (
+                <div className={"prose"}>
+                    <PortableText value={descriptionBlock} components={components} />
+                </div>
+            ) : (
+                <Markdown className={"prose my-5 max-w-none"} markdown={description} />
+            )}
         </div>
         {buttonUrl && (
             <div className={"flex justify-center"}>

--- a/components/cards/singleInfoCard.tsx
+++ b/components/cards/singleInfoCard.tsx
@@ -5,8 +5,8 @@ import Markdown from "@/components/markdown"
 import { ExternalLink } from "@/components/link"
 import type { MarkdownString, SanityImageObject } from "@/sanity/types"
 import { PortableText } from "@portabletext/react"
-import { type TypedObject } from "sanity"
 import { components } from "@/sanity/lib/portabletext"
+import type { TypedObject } from "sanity"
 
 interface SingleInfoCardProps extends ChildProps {
     image?: SanityImageObject

--- a/components/omOss/InfoPageContent.tsx
+++ b/components/omOss/InfoPageContent.tsx
@@ -24,7 +24,11 @@ export const InfoPageContent: Component<{
             <div>
                 {infoSider.map((side: InfoSide) => (
                     <section id={side._id} key={side._id} className={"mb-16 scroll-mt-44"}>
-                        <SingleInfoCard image={side.image} description={side.info} />
+                        <SingleInfoCard
+                            image={side.image}
+                            description={side.info}
+                            descriptionBlock={side.info_block}
+                        />
                     </section>
                 ))}
             </div>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@heroicons/react": "^2.1.1",
         "@nextui-org/react": "^2.2.9",
+        "@portabletext/react": "^3.0.11",
         "@sanity/asset-utils": "^1.3.0",
         "@sanity/client": "^6.8.0",
         "@sanity/image-url": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@sanity-typed/types':
         specifier: ^6.3.2
         version: 6.3.2(@portabletext/types@2.0.8)(sanity@3.26.1)(typescript@5.2.2)
+      '@tailwindcss/typography':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@3.4.1)
       '@types/node':
         specifier: ^20.9.0
         version: 20.9.0
@@ -3980,6 +3983,18 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@tailwindcss/typography@0.5.10(tailwindcss@3.4.1):
+    resolution: {integrity: sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.1
+    dev: true
+
   /@tanstack/react-virtual@3.0.0-beta.54(react@18.2.0):
     resolution: {integrity: sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==}
     peerDependencies:
@@ -6762,6 +6777,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
+  /lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+    dev: true
+
   /lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -7617,6 +7636,14 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
+
+  /postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: true
 
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,108 +4,113 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@heroicons/react':
-    specifier: ^2.1.1
-    version: 2.1.1(react@18.2.0)
-  '@nextui-org/react':
-    specifier: ^2.2.9
-    version: 2.2.9(@types/react@18.2.37)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwind-variants@0.1.18)(tailwindcss@3.4.1)
-  '@sanity/asset-utils':
-    specifier: ^1.3.0
-    version: 1.3.0
-  '@sanity/client':
-    specifier: ^6.8.0
-    version: 6.8.0
-  '@sanity/image-url':
-    specifier: ^1.0.2
-    version: 1.0.2
-  '@sanity/vision':
-    specifier: ^3.19.2
-    version: 3.19.2(@babel/runtime@7.23.9)(@codemirror/lint@6.4.2)(@codemirror/state@6.3.1)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.1.0)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.11)
-  framer-motion:
-    specifier: ^10.16.4
-    version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
-  groq:
-    specifier: ^3.19.2
-    version: 3.19.2
-  ics:
-    specifier: ^3.5.0
-    version: 3.5.0
-  next:
-    specifier: ^14.0.2
-    version: 14.0.2(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
-  next-sanity:
-    specifier: ^6.0.1
-    version: 6.0.1(@sanity/client@6.8.0)(@sanity/icons@2.10.0)(@sanity/types@3.26.1)(@sanity/ui@1.8.3)(next@14.0.2)(react@18.2.0)(sanity@3.26.1)(styled-components@5.3.11)
-  react:
-    specifier: ^18.2.0
-    version: 18.2.0
-  react-dom:
-    specifier: ^18.2.0
-    version: 18.2.0(react@18.2.0)
-  react-use-keypress:
-    specifier: ^1.3.1
-    version: 1.3.1(react@18.2.0)
-  remark:
-    specifier: ^15.0.1
-    version: 15.0.1
-  remark-html:
-    specifier: ^16.0.1
-    version: 16.0.1
-  sanity:
-    specifier: ^3.26.1
-    version: 3.26.1(@types/node@20.9.0)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
-  sanity-plugin-markdown:
-    specifier: ^4.1.0
-    version: 4.1.0(easymde@2.18.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.26.1)(styled-components@5.3.11)
-  strip-markdown:
-    specifier: ^6.0.0
-    version: 6.0.0
-  styled-components:
-    specifier: ^5.3.11
-    version: 5.3.11(@babel/core@7.23.9)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+importers:
 
-devDependencies:
-  '@sanity-typed/types':
-    specifier: ^6.3.2
-    version: 6.3.2(@portabletext/types@2.0.8)(sanity@3.26.1)(typescript@5.2.2)
-  '@types/node':
-    specifier: ^20.9.0
-    version: 20.9.0
-  '@types/react':
-    specifier: ^18.2.37
-    version: 18.2.37
-  '@types/react-dom':
-    specifier: ^18.2.15
-    version: 18.2.15
-  autoprefixer:
-    specifier: ^10.4.16
-    version: 10.4.16(postcss@8.4.31)
-  eslint:
-    specifier: ^8.53.0
-    version: 8.53.0
-  eslint-config-next:
-    specifier: ^14.0.2
-    version: 14.0.2(eslint@8.53.0)(typescript@5.2.2)
-  eslint-config-prettier:
-    specifier: ^9.0.0
-    version: 9.0.0(eslint@8.53.0)
-  postcss:
-    specifier: ^8.4.31
-    version: 8.4.31
-  prettier:
-    specifier: ^3.0.3
-    version: 3.0.3
-  prettier-plugin-tailwindcss:
-    specifier: ^0.5.7
-    version: 0.5.7(prettier@3.0.3)
-  tailwindcss:
-    specifier: ^3.4.1
-    version: 3.4.1
-  typescript:
-    specifier: ^5.2.2
-    version: 5.2.2
+  .:
+    dependencies:
+      '@heroicons/react':
+        specifier: ^2.1.1
+        version: 2.1.1(react@18.2.0)
+      '@nextui-org/react':
+        specifier: ^2.2.9
+        version: 2.2.9(@types/react@18.2.37)(framer-motion@10.16.4)(react-dom@18.2.0)(react@18.2.0)(tailwind-variants@0.1.18)(tailwindcss@3.4.1)
+      '@portabletext/react':
+        specifier: ^3.0.11
+        version: 3.0.11(react@18.2.0)
+      '@sanity/asset-utils':
+        specifier: ^1.3.0
+        version: 1.3.0
+      '@sanity/client':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@sanity/image-url':
+        specifier: ^1.0.2
+        version: 1.0.2
+      '@sanity/vision':
+        specifier: ^3.19.2
+        version: 3.19.2(@babel/runtime@7.23.9)(@codemirror/lint@6.4.2)(@codemirror/state@6.3.1)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.1.0)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.11)
+      framer-motion:
+        specifier: ^10.16.4
+        version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      groq:
+        specifier: ^3.19.2
+        version: 3.19.2
+      ics:
+        specifier: ^3.5.0
+        version: 3.5.0
+      next:
+        specifier: ^14.0.2
+        version: 14.0.2(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
+      next-sanity:
+        specifier: ^6.0.1
+        version: 6.0.1(@sanity/client@6.8.0)(@sanity/icons@2.10.0)(@sanity/types@3.26.1)(@sanity/ui@1.8.3)(next@14.0.2)(react@18.2.0)(sanity@3.26.1)(styled-components@5.3.11)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      react-use-keypress:
+        specifier: ^1.3.1
+        version: 1.3.1(react@18.2.0)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-html:
+        specifier: ^16.0.1
+        version: 16.0.1
+      sanity:
+        specifier: ^3.26.1
+        version: 3.26.1(@types/node@20.9.0)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
+      sanity-plugin-markdown:
+        specifier: ^4.1.0
+        version: 4.1.0(easymde@2.18.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.26.1)(styled-components@5.3.11)
+      strip-markdown:
+        specifier: ^6.0.0
+        version: 6.0.0
+      styled-components:
+        specifier: ^5.3.11
+        version: 5.3.11(@babel/core@7.23.9)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+    devDependencies:
+      '@sanity-typed/types':
+        specifier: ^6.3.2
+        version: 6.3.2(@portabletext/types@2.0.8)(sanity@3.26.1)(typescript@5.2.2)
+      '@types/node':
+        specifier: ^20.9.0
+        version: 20.9.0
+      '@types/react':
+        specifier: ^18.2.37
+        version: 18.2.37
+      '@types/react-dom':
+        specifier: ^18.2.15
+        version: 18.2.15
+      autoprefixer:
+        specifier: ^10.4.16
+        version: 10.4.16(postcss@8.4.31)
+      eslint:
+        specifier: ^8.53.0
+        version: 8.53.0
+      eslint-config-next:
+        specifier: ^14.0.2
+        version: 14.0.2(eslint@8.53.0)(typescript@5.2.2)
+      eslint-config-prettier:
+        specifier: ^9.0.0
+        version: 9.0.0(eslint@8.53.0)
+      postcss:
+        specifier: ^8.4.31
+        version: 8.4.31
+      prettier:
+        specifier: ^3.0.3
+        version: 3.0.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.5.7
+        version: 0.5.7(prettier@3.0.3)
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.1
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
 
 packages:
 

--- a/sanity/lib/portabletext.tsx
+++ b/sanity/lib/portabletext.tsx
@@ -1,0 +1,9 @@
+import { PortableTextComponents } from "@portabletext/react"
+
+// TODO
+export const components: PortableTextComponents = {
+    marks: {
+        p: ({ children }) => <p>{children}</p>,
+        li: ({ children }) => <li className={"text-black"}>{children}</li>,
+    },
+}

--- a/sanity/lib/portabletext.tsx
+++ b/sanity/lib/portabletext.tsx
@@ -1,9 +1,17 @@
-import { PortableTextComponents } from "@portabletext/react"
+import { type PortableTextComponents } from "@portabletext/react"
+import { ExternalLink } from "@/components/link"
 
-// TODO
+/**
+ * Definerer custom styling for komponenter generert av PortableText.
+ * Brukes av PortableText komponenten, for å style tekst og komponenter.
+ * @see https://www.npmjs.com/package/@portabletext/react#available-components
+ */
 export const components: PortableTextComponents = {
     marks: {
-        p: ({ children }) => <p>{children}</p>,
-        li: ({ children }) => <li className={"text-black"}>{children}</li>,
+        link: ({ value, children }) => (
+            <ExternalLink href={value?.href} className={"link"}>
+                {children}
+            </ExternalLink>
+        ),
     },
 }

--- a/sanity/lib/portabletext.tsx
+++ b/sanity/lib/portabletext.tsx
@@ -1,5 +1,6 @@
 import { type PortableTextComponents } from "@portabletext/react"
 import { ExternalLink } from "@/components/link"
+import { Code } from "@nextui-org/code"
 
 /**
  * Definerer custom styling for komponenter generert av PortableText.
@@ -12,6 +13,9 @@ export const components: PortableTextComponents = {
             <ExternalLink href={value?.href} className={"link"}>
                 {children}
             </ExternalLink>
+        ),
+        code: ({ children }) => (
+            <Code className={"before:content-[''] after:content-['']"}>{children}</Code>
         ),
     },
     block: {

--- a/sanity/lib/portabletext.tsx
+++ b/sanity/lib/portabletext.tsx
@@ -14,4 +14,12 @@ export const components: PortableTextComponents = {
             </ExternalLink>
         ),
     },
+    block: {
+        h1: ({ children }) => <h1 className={"text-dark-title"}>{children}</h1>,
+        h2: ({ children }) => <h2 className={"text-dark-title"}>{children}</h2>,
+        h3: ({ children }) => <h3 className={"text-dark-title"}>{children}</h3>,
+        h4: ({ children }) => <h4 className={"text-dark-title"}>{children}</h4>,
+        h5: ({ children }) => <h5 className={"text-dark-title"}>{children}</h5>,
+        h6: ({ children }) => <h6 className={"text-dark-title"}>{children}</h6>,
+    },
 }

--- a/sanity/lib/utils.ts
+++ b/sanity/lib/utils.ts
@@ -2,6 +2,8 @@ import { remark } from "remark"
 import html from "remark-html"
 import strip from "strip-markdown"
 import type { EventType, MarkdownString } from "@/sanity/types"
+import { toPlainText } from "@portabletext/react"
+import { PortableTextBlock } from "sanity"
 
 /**
  * Konverterer markdown til html
@@ -21,6 +23,24 @@ export async function markdownToHTML(markdown?: MarkdownString): Promise<string>
 export async function markdownToText(markdown?: MarkdownString): Promise<string> {
     const file = await remark().use(strip).process(markdown)
     return file.toString()
+}
+
+/**
+ * Henter ut beskrivelsen på block format om den finnes, ellers henter den ut beskrivelsen på markdown format og konverterer den til ren tekst.
+ * @param event Eventet som beskrivelsen skal hentes fra
+ * @returns Beskrivelsen på ren tekst format. Dersom begge er undefined returneres en tom streng.
+ */
+export async function getDescription(event: {
+    description?: MarkdownString
+    description_block?: PortableTextBlock[]
+}): Promise<string> {
+    let description: string
+    if (event.description_block) {
+        description = toPlainText(event.description_block)
+    } else {
+        description = await markdownToText(event.description)
+    }
+    return description
 }
 
 /**

--- a/sanity/schemas/event.ts
+++ b/sanity/schemas/event.ts
@@ -25,15 +25,6 @@ export default defineType({
             },
         }),
         defineField({
-            name: "description",
-            type: "markdown",
-            title: "Fullstendig beskrivelse",
-            description: "Inkluder brødtekst med utdypende informasjon om eventet",
-            deprecated: {
-                reason: "Bruk 'block' istedenfor",
-            },
-        }),
-        defineField({
             name: "description_block",
             title: "Fullstendig beskrivelse",
             description: "Inkluder brødtekst med utdypende informasjon om eventet",
@@ -117,6 +108,15 @@ export default defineType({
             type: "url",
             title: "Lenke for påmelding",
             description: "Her kan du legge inn en lenke til påmeldingsskjemas",
+        }),
+        defineField({
+            name: "description",
+            type: "markdown",
+            title: "Fullstendig beskrivelse",
+            description: "Inkluder brødtekst med utdypende informasjon om eventet",
+            deprecated: {
+                reason: "Bruk 'Fullstendig beskrivelse' over istedenfor",
+            },
         }),
     ],
 })

--- a/sanity/schemas/event.ts
+++ b/sanity/schemas/event.ts
@@ -1,4 +1,4 @@
-import { defineType, defineField } from "@sanity-typed/types"
+import { defineType, defineField, defineArrayMember } from "@sanity-typed/types"
 import { CalendarIcon } from "@heroicons/react/24/outline"
 
 export default defineType({
@@ -29,6 +29,16 @@ export default defineType({
             type: "markdown",
             title: "Fullstendig beskrivelse",
             description: "Inkluder brødtekst med utdypende informasjon om eventet",
+            deprecated: {
+                reason: "Bruk 'block' istedenfor",
+            },
+        }),
+        defineField({
+            name: "description_block",
+            title: "Fullstendig beskrivelse",
+            description: "Inkluder brødtekst med utdypende informasjon om eventet",
+            type: "array",
+            of: [defineArrayMember({ type: "block" })],
         }),
         defineField({
             name: "type",

--- a/sanity/schemas/jobAdvert.ts
+++ b/sanity/schemas/jobAdvert.ts
@@ -1,4 +1,4 @@
-import { defineField, defineType } from "@sanity-typed/types"
+import { defineArrayMember, defineField, defineType } from "@sanity-typed/types"
 import { BriefcaseIcon } from "@heroicons/react/24/outline"
 
 export default defineType({
@@ -38,10 +38,11 @@ export default defineType({
             validation: Rule => Rule.required(),
         }),
         defineField({
-            name: "description",
-            type: "markdown",
-            title: "Beskrivelse",
-            description: "Inkluder brødtekst med utdypende informasjon om stillingen",
+            name: "description_block",
+            title: "Fullstendig beskrivelse",
+            description: "Inkluder brødtekst med utdypende informasjon om eventet",
+            type: "array",
+            of: [defineArrayMember({ type: "block" })],
         }),
         defineField({
             name: "deadline",
@@ -70,6 +71,15 @@ export default defineType({
                     validation: Rule => Rule.required(),
                 }),
             ],
+        }),
+        defineField({
+            name: "description",
+            type: "markdown",
+            title: "Beskrivelse",
+            description: "Inkluder brødtekst med utdypende informasjon om stillingen",
+            deprecated: {
+                reason: "Bruk 'Fullstendig beskrivelse' over i stedet",
+            },
         }),
     ],
 })

--- a/sanity/schemas/omOss/infoSider.ts
+++ b/sanity/schemas/omOss/infoSider.ts
@@ -1,4 +1,4 @@
-import { defineField, defineType } from "@sanity-typed/types"
+import { defineArrayMember, defineField, defineType } from "@sanity-typed/types"
 import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/outline"
 
 export default defineType({
@@ -10,7 +10,8 @@ export default defineType({
         defineField({
             name: "title",
             type: "string",
-            title: "Info side om hva",
+            title: "Kort tittel",
+            description: "Vises på navigasjonsbaren. Vil ikke vises over innholdet på siden",
             validation: Rule => Rule.required(),
         }),
         defineField({
@@ -18,7 +19,7 @@ export default defineType({
             type: "number",
             title: "Prioritet",
             description:
-                "Laveste tall blir prioritert først hvis noen har samme tall blir det sortet på alfabetisk rekkefølge",
+                "Laveste tall blir prioritert først, hvis noen har samme tall blir det sortet på alfabetisk rekkefølge",
             validation: Rule => Rule.required(),
         }),
         defineField({
@@ -38,10 +39,20 @@ export default defineType({
             ],
         }),
         defineField({
+            name: "info_block",
+            title: "Informasjon",
+            description: "Teksten som blir vist på siden",
+            type: "array",
+            of: [defineArrayMember({ type: "block" })],
+        }),
+        defineField({
             name: "info",
             type: "markdown",
             title: "Informasjonen",
             description: "Tesket som blir vist på siden",
+            deprecated: {
+                reason: "Bruk heller 'Informasjon' over",
+            },
         }),
     ],
 })


### PR DESCRIPTION
Deprecated Markdown feltene og erstattet de med rich text Block felter.

Sidene vil bruke Block dersom det er fylt ut, hvis ikke vil det defaulte til Markdown.

Bruker PortableText for å formatere teksten.